### PR TITLE
トークンの有効期限を5分から30分に延長した。

### DIFF
--- a/backend/api/src/main/kotlin/com/proelbtn/linesc/controller/TokenController.kt
+++ b/backend/api/src/main/kotlin/com/proelbtn/linesc/controller/TokenController.kt
@@ -56,7 +56,7 @@ class TokenController {
 
             val jedis = Jedis("localhost")
             jedis.set(token, user[Users.id].toString())
-            jedis.expire(token, 300)
+            jedis.expire(token, 1800)
         }
 
         return TokenResponse(token)


### PR DESCRIPTION
クライアント側の方でトークンをIntentを用いて各Activityに渡す実装にしたとしても有効期限の制限にひっかからないようにするためのもの。